### PR TITLE
read the sdf model using kdl_parser's utilities

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -13,5 +13,6 @@
   <depend package="control/sdformat" />
   <depend package="gui/vizkit3d" />
   <depend package="gui/robot_model" />
+  <depend package="control/kdl_parser" />
   
 </package>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ rock_library(vizkit3d_world
         sdformat
         vizkit3d
         robot_model-viz
+        kdl_parser
 )
 
 rock_executable(vizkit3d_world_bin

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -6,7 +6,7 @@
 #include <vizkit3d/Vizkit3DWidget.hpp>
 #include <vizkit3d_world/Vizkit3dWorld.hpp>
 #include <opencv/cv.h>
-#include <opencv/highgui.h>
+#include <opencv2/highgui/highgui.hpp>
 #include <frame_helper/FrameHelper.h>
 
 vizkit3d_world::Vizkit3dWorld *g_world = NULL;

--- a/src/Vizkit3dWorld.cpp
+++ b/src/Vizkit3dWorld.cpp
@@ -15,6 +15,7 @@
 #include <osgViewer/View>
 #include <base-logging/Logging.hpp>
 #include "Utils.hpp"
+#include <kdl_parser/RobotModelFormat.hpp>
 
 namespace vizkit3d_world {
 
@@ -52,7 +53,7 @@ Vizkit3dWorld::Vizkit3dWorld(std::string path,
     applyCameraParams();
 
     this->ignoredModels = ignoredModels;
-    //load the world sdf file and created the vizkit3d::RobotVisualization models
+    //load the world sdf file and create the vizkit3d::RobotVisualization models
     //It is necessary to create the vizkit3d plugins in the same thread of QApplication
     loadFromFile(worldPath);
     attachPlugins();
@@ -75,9 +76,9 @@ Vizkit3dWorld::~Vizkit3dWorld()
 }
 
 void Vizkit3dWorld::loadFromFile(std::string path) {
-    std::ifstream file(path.c_str());
-    std::string str((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-    loadFromString(str);
+    std::pair<std::string, int> sdf_string = getRobotModelString(
+        path, kdl_parser::ROBOT_MODEL_FORMAT::ROBOT_MODEL_AUTO);
+    loadFromString(sdf_string.first);
 }
 
 void Vizkit3dWorld::loadFromString(const std::string xml) {

--- a/src/Vizkit3dWorld.cpp
+++ b/src/Vizkit3dWorld.cpp
@@ -16,6 +16,7 @@
 #include <base-logging/Logging.hpp>
 #include "Utils.hpp"
 #include <kdl_parser/RobotModelFormat.hpp>
+#include <locale.h>     /* struct lconv, setlocale, localeconv */
 
 namespace vizkit3d_world {
 
@@ -35,11 +36,14 @@ Vizkit3dWorld::Vizkit3dWorld(std::string path,
     , zFar(zFar)
     , horizontalFov(horizontalFov)
 {
+    
     loadGazeboModelPaths(modelPaths);
 
     int argc = 1;
     char const*argv[] = { "vizkit3d_world" };
     app = new QApplication(argc, const_cast<char**>(argv));
+    //Qt application changes the locale information, what crashes the sdf initialization
+    setlocale(LC_ALL, "C");
 
     //main widget to store the plugins and performs the GUI events
     widget = new vizkit3d::Vizkit3DWidget(NULL, cameraWidth, cameraHeight, "world_osg", false);

--- a/src/Vizkit3dWorld.hpp
+++ b/src/Vizkit3dWorld.hpp
@@ -105,7 +105,7 @@ public:
     void grabFrame(base::samples::frame::Frame& frame);
 
 
-     void setCameraParams(int cameraWidth, int cameraHeight, double horizontalFov, double zNear, double zFar);
+    void setCameraParams(int cameraWidth, int cameraHeight, double horizontalFov, double zNear, double zFar);
 
 protected:
 

--- a/src/Vizkit3dWorld.hpp
+++ b/src/Vizkit3dWorld.hpp
@@ -33,7 +33,7 @@ public:
      * @param path: the string with the path to the sdf world file
      * @param modelPaths: list with paths to models
      */
-    Vizkit3dWorld(std::string path = std::string(""),
+    Vizkit3dWorld(std::string path,
                   std::vector<std::string> modelPaths = std::vector<std::string>(),
                   std::vector<std::string> ignoredModels = std::vector<std::string>(),
                   int cameraWidth = 800, int cameraHeight = 600,

--- a/test/testVizkit3dWorld.cpp
+++ b/test/testVizkit3dWorld.cpp
@@ -8,3 +8,18 @@ BOOST_AUTO_TEST_CASE(it_should_not_crash_when_welcome_is_called)
 {
     vizkit3d_world::Vizkit3dWorld vizkit3d_world;
 }
+
+BOOST_AUTO_TEST_CASE(it_starts_sdf)
+{   
+    std::string path = "test_data/simple.world";
+    std::pair<std::string, int> sdf_string = getRobotModelString(
+        path, kdl_parser::ROBOT_MODEL_FORMAT::ROBOT_MODEL_AUTO);
+    sdf::SDFPtr sdf(new sdf::SDF);
+    sdf::init(sdf);
+}
+
+
+//BOOST_AUTO_TEST_CASE(it_loads_correctly_a_sdf_world)
+//{
+//    vizkit3d_world::Vizkit3dWorld vizkit3d_world("test_data/simple.world");
+//}

--- a/test/testVizkit3dWorld.cpp
+++ b/test/testVizkit3dWorld.cpp
@@ -4,22 +4,10 @@
 
 using namespace vizkit3d_world;
 
-BOOST_AUTO_TEST_CASE(it_should_not_crash_when_welcome_is_called)
+BOOST_AUTO_TEST_CASE(it_loads_correctly_a_sdf_world)
 {
-    vizkit3d_world::Vizkit3dWorld vizkit3d_world;
+    vizkit3d_world::Vizkit3dWorld vizkit3d_world("test_data/simple.world");
+    RobotVizMap robot_viz = vizkit3d_world.getRobotVizMap();
+    BOOST_TEST(robot_viz.size(),1);
+    BOOST_CHECK_EQUAL(robot_viz.begin()->first,"simple_model");
 }
-
-BOOST_AUTO_TEST_CASE(it_starts_sdf)
-{   
-    std::string path = "test_data/simple.world";
-    std::pair<std::string, int> sdf_string = getRobotModelString(
-        path, kdl_parser::ROBOT_MODEL_FORMAT::ROBOT_MODEL_AUTO);
-    sdf::SDFPtr sdf(new sdf::SDF);
-    sdf::init(sdf);
-}
-
-
-//BOOST_AUTO_TEST_CASE(it_loads_correctly_a_sdf_world)
-//{
-//    vizkit3d_world::Vizkit3dWorld vizkit3d_world("test_data/simple.world");
-//}

--- a/test_data/simple.world
+++ b/test_data/simple.world
@@ -1,9 +1,8 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
     <world name="simple">
-        <include>
+        <model name='simple_model'>
             <pose>0 0 0 0 0 0</pose>
-            <uri>model://simple_arm</uri>
-        </include>
+        </model>
     </world>
 </sdf>

--- a/test_data/simple.world
+++ b/test_data/simple.world
@@ -1,13 +1,9 @@
 <?xml version="1.0" ?>
-<sdf version="1.4">
-
+<sdf version="1.6">
     <world name="simple">
-        
         <include>
             <pose>0 0 0 0 0 0</pose>
             <uri>model://simple_arm</uri>
         </include>
-        
     </world>
-    
 </sdf>


### PR DESCRIPTION
This allows us to provide the XML as a string or as a file.

Integration in Syskit normalizes on providing resolved SDF models as strings.