### PR TITLE
remove nonsensical RGB swap

### DIFF
--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -126,7 +126,6 @@ inline void cvtQImageToFrame(const QImage& src, base::samples::frame::Frame& dst
             QImage rgb24 = src.convertToFormat(QImage::Format_RGB888);
             dst.init(src.width(), src.height(), 8, base::samples::frame::MODE_BGR, -1);
             dst.setStatus(base::samples::frame::STATUS_VALID);
-            rgb24 = rgb24.rgbSwapped();
             cpyQImageToFrame(rgb24, dst, flipImage);
         }
         break;


### PR DESCRIPTION
The frame mode is set to BGR which is correct. The swap was probably
added because there is code in the underwater camera simulation that
forcefully changes the pixel format to RGB.